### PR TITLE
Make the read and write timeouts configurable via JSON file

### DIFF
--- a/sdsConfig.json
+++ b/sdsConfig.json
@@ -2,6 +2,8 @@
     "cacheLocation": "./sdscache/",
     "cacheMaxBytes": 100000000,
     "checkCacheEvery": 60,
+    "read_timeout": 300,
+    "write_timeout": 300,
     "locationDetails": [
         {
             "location": "",

--- a/sds_types.go
+++ b/sds_types.go
@@ -126,6 +126,8 @@ type Location struct {
 // Configuration Struct for Configuraion File
 type Configuration struct {
 	Port             int        `json:"port"`
+	ReadTimeout      int        `json:"read_timeout"`
+	WriteTimeout     int        `json:"write_timeout"`
 	CacheLocation    string     `json:"cacheLocation"`
 	Logfile          string     `json:"logfile"`
 	CacheMaxBytes    int64      `json:"cacheMaxBytes"`

--- a/sigplot_data_service.go
+++ b/sigplot_data_service.go
@@ -2233,10 +2233,22 @@ func main() {
 	msg := ":%d"
 	bindAddr := fmt.Sprintf(msg, configuration.Port)
 
+	// Set sane defaults if ReadTimeout and WriteTimeout are not set.
+	// Recall: if they aren't set, they'll default to 0.
+	readTimeout := configuration.ReadTimeout
+	if readTimeout == 0 {
+		readTimeout = 240
+	}
+
+	writeTimeout := configuration.WriteTimeout
+	if writeTimeout == 0 {
+		writeTimeout = 30
+	}
+
 	svr := &http.Server{
 		Addr:           bindAddr,
-		ReadTimeout:    240 * time.Second,
-		WriteTimeout:   30 * time.Second,
+		ReadTimeout:    time.Duration(readTimeout) * time.Second,
+		WriteTimeout:   time.Duration(writeTimeout) * time.Second,
 		MaxHeaderBytes: 1 << 20,
 	}
 	log.Fatal(svr.ListenAndServe())


### PR DESCRIPTION
Based on feedback that I just received from @weishiuchang about large files being truncated because of

https://github.com/spectriclabs/sigplot-data-service/blob/d1e07798d72f4607fb9b37199b1626a82a158992/sigplot_data_service.go#L2238-L2239

This PR adds the ability to configure both timeouts in `sdsConfig.json`. If none are provided, it defaults to the current hardcoded values. (Note: this makes the assumption that no one will ever reasonably have timeouts set to 0.)